### PR TITLE
feat: parallelize server initialization and tool refresh

### DIFF
--- a/server/schemas/config.schema.json
+++ b/server/schemas/config.schema.json
@@ -313,13 +313,13 @@
           "properties": {
             "global": {
               "type": "number",
-              "default": 8
+              "default": 4
             },
-            "perServer": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "number"
-              }
+            "serverInit": {
+              "type": "number"
+            },
+            "warmup": {
+              "type": "number"
             }
           },
           "additionalProperties": false,

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -123,7 +123,7 @@ export function createDefaultConfig(): HatagoConfig {
       toolCallMs: 20000,
     },
     concurrency: {
-      global: 8,
+      global: 4,
     },
     security: {
       redactKeys: ['password', 'apiKey', 'token', 'secret'],
@@ -376,13 +376,13 @@ export function generateSampleConfig(): string {
   // Concurrency limits
   "concurrency": {
     // Maximum concurrent operations across all servers
-    "global": 8,
-    
-    // Per-server concurrency limits
-    // Overrides global limit for specific servers
-    "perServer": {
-      // "example-local": 3
-    }
+    "global": 4,
+
+    // Concurrency for server initialization
+    "serverInit": 4,
+
+    // Concurrency for NPX package warmup
+    "warmup": 4
   },
   
   // Security configuration

--- a/server/src/config/schema.ts
+++ b/server/src/config/schema.ts
@@ -262,13 +262,13 @@ export const CONFIG_SCHEMA = {
           properties: {
             global: {
               type: 'number',
-              default: 8,
+              default: 4,
             },
-            perServer: {
-              type: 'object',
-              additionalProperties: {
-                type: 'number',
-              },
+            serverInit: {
+              type: 'number',
+            },
+            warmup: {
+              type: 'number',
             },
           },
           additionalProperties: false,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -50,8 +50,9 @@ export type TimeoutsConfig = z.infer<typeof TimeoutsConfigSchema>;
 
 // 並列実行設定
 export const ConcurrencyConfigSchema = z.object({
-  global: z.number().default(8),
-  perServer: z.record(z.number()).optional(),
+  global: z.number().default(4),
+  serverInit: z.number().optional(),
+  warmup: z.number().optional(),
 });
 export type ConcurrencyConfig = z.infer<typeof ConcurrencyConfigSchema>;
 


### PR DESCRIPTION
## Summary
- parallelize server connection using a task queue and run NPX package warmup concurrently
- fetch tools, resources, and prompts in parallel when connecting servers
- use keyed mutex for tool registration to reduce contention

## Testing
- `pnpm format`
- `cd server && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae62eb0294832f8a83ae99b1cd7afd