### PR TITLE
chore: Phase 2 lint hardening + STDIO/HTTP config safety

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default tseslint.config(
         'error',
         {
           checksVoidReturn: {
-            arguments: false
+            arguments: true
           }
         }
       ],
@@ -66,9 +66,13 @@ export default tseslint.config(
       '@typescript-eslint/explicit-function-return-type': 'off', // Still off - too restrictive
       '@typescript-eslint/explicit-module-boundary-types': 'off', // Still off - too restrictive
       '@typescript-eslint/require-await': 'error',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'warn', // Start with warn
-      '@typescript-eslint/prefer-nullish-coalescing': 'warn', // Phase 1: start with warn
-      '@typescript-eslint/prefer-optional-chain': 'error', // Phase 1: promote to error
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+      '@typescript-eslint/prefer-optional-chain': 'error',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      '@typescript-eslint/only-throw-error': 'error',
+      '@typescript-eslint/return-await': ['error', 'in-try-catch'],
+      '@typescript-eslint/no-non-null-assertion': 'warn',
 
       // Phase 1 additions (mostly auto-fixable or low-risk)
       '@typescript-eslint/no-useless-empty-export': 'error',

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -7,7 +7,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 
-interface HatagoConfig {
+type HatagoConfig = {
   port?: number;
   host?: string;
   servers?: unknown[];
@@ -15,7 +15,7 @@ interface HatagoConfig {
     timeout?: number;
     maxSessions?: number;
   };
-}
+};
 
 export function setupConfigCommand(program: Command): void {
   const config = program.command('config').description('Manage Hatago configuration');

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,11 +6,11 @@ import { existsSync, writeFileSync } from 'node:fs';
 import { generateDefaultConfig } from '@himorishige/hatago-server';
 import type { Command } from 'commander';
 
-interface InitOptions {
+type InitOptions = {
   config?: string;
   force?: boolean;
   verbose?: boolean;
-}
+};
 
 export function setupInitCommand(program: Command): void {
   program

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -7,14 +7,14 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
 
-interface McpServer {
+type McpServer = {
   id: string;
   type: 'local' | 'npx' | 'remote';
   command?: string;
   args?: string[];
   url?: string;
   transport?: 'stdio' | 'http' | 'sse';
-}
+};
 
 export function setupMcpCommand(program: Command): void {
   const mcp = program.command('mcp').description('Manage MCP servers');

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -5,7 +5,7 @@
 import { startServer } from '@himorishige/hatago-server';
 import type { Command } from 'commander';
 
-interface ServeOptions {
+type ServeOptions = {
   mode?: 'stdio' | 'http';
   config?: string;
   port?: string;
@@ -14,7 +14,7 @@ interface ServeOptions {
   quiet?: boolean;
   stdio?: boolean;
   http?: boolean;
-}
+};
 
 export function setupServeCommand(program: Command): void {
   program

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -73,7 +73,7 @@ export enum ErrorSeverity {
 /**
  * Extended error information
  */
-export interface ErrorContext {
+export type ErrorContext = {
   serverId?: string;
   sessionId?: string;
   toolName?: string;
@@ -81,4 +81,4 @@ export interface ErrorContext {
   timestamp?: Date;
   stack?: string;
   [key: string]: unknown;
-}
+};

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -6,49 +6,49 @@
 /**
  * Server lifecycle events
  */
-export interface ServerEvents {
+export type ServerEvents = {
   'server:started': { serverId: string; timestamp: Date };
   'server:stopped': { serverId: string; timestamp: Date };
   'server:error': { serverId: string; error: Error; timestamp: Date };
   'server:reconnecting': { serverId: string; attempt: number; timestamp: Date };
   'server:reconnected': { serverId: string; timestamp: Date };
-}
+};
 
 /**
  * Tool discovery events
  */
-export interface ToolEvents {
+export type ToolEvents = {
   'tools:discovered': { serverId: string; count: number; timestamp: Date };
   'tools:registered': { serverId: string; tools: string[]; timestamp: Date };
   'tools:removed': { serverId: string; tools: string[]; timestamp: Date };
-}
+};
 
 /**
  * Resource discovery events
  */
-export interface ResourceEvents {
+export type ResourceEvents = {
   'resources:discovered': { serverId: string; count: number; timestamp: Date };
   'resources:registered': { serverId: string; uris: string[]; timestamp: Date };
   'resources:removed': { serverId: string; uris: string[]; timestamp: Date };
-}
+};
 
 /**
  * Prompt discovery events
  */
-export interface PromptEvents {
+export type PromptEvents = {
   'prompts:discovered': { serverId: string; count: number; timestamp: Date };
   'prompts:registered': { serverId: string; names: string[]; timestamp: Date };
   'prompts:removed': { serverId: string; names: string[]; timestamp: Date };
-}
+};
 
 /**
  * Session lifecycle events
  */
-export interface SessionEvents {
+export type SessionEvents = {
   'session:created': { sessionId: string; timestamp: Date };
   'session:expired': { sessionId: string; timestamp: Date };
   'session:deleted': { sessionId: string; timestamp: Date };
-}
+};
 
 /**
  * All event types

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -11,7 +11,7 @@ export interface LogData {
   [key: string]: unknown;
 }
 
-export interface Logger {
+export type Logger = {
   level: LogLevel;
   error(obj: unknown, msg?: string): void;
   warn(obj: unknown, msg?: string): void;
@@ -19,7 +19,7 @@ export interface Logger {
   debug(obj: unknown, msg?: string): void;
   trace(obj: unknown, msg?: string): void;
   child?(prefix: string): Logger;
-}
+};
 
 /**
  * Log levels with numeric values for comparison

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -7,9 +7,9 @@
 
 export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
 
-export interface LogData {
+export type LogData = {
   [key: string]: unknown;
-}
+};
 
 export type Logger = {
   level: LogLevel;

--- a/packages/core/src/types/connection.ts
+++ b/packages/core/src/types/connection.ts
@@ -11,7 +11,7 @@ export type ConnectionType = 'local' | 'npx' | 'remote';
 /**
  * MCP Connection information
  */
-export interface McpConnection {
+export type McpConnection = {
   serverId: string;
   type: ConnectionType;
   connected: boolean;
@@ -20,4 +20,4 @@ export interface McpConnection {
   transport?: unknown;
   npxServer?: unknown; // NPX server instance
   remoteServer?: unknown; // Remote server instance
-}
+};

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -14,56 +14,56 @@ export type { Session } from './session.js';
 // Additional types that were missing
 export type ToolNamingStrategy = 'prefix' | 'suffix' | 'none' | 'namespace' | 'error' | 'alias';
 
-export interface ToolCallResult {
+export type ToolCallResult = {
   success: boolean;
   result?: unknown;
   error?: Error;
-}
+};
 
-export interface ResourceTemplate {
+export type ResourceTemplate = {
   uriTemplate: string;
   name: string;
   description?: string;
   mimeType?: string;
-}
+};
 
-export interface PromptArgument {
+export type PromptArgument = {
   name: string;
   description?: string;
   required?: boolean;
-}
+};
 
-export interface SessionData {
+export type SessionData = {
   id: string;
   createdAt: number;
   expiresAt: number;
   data?: Record<string, unknown>;
-}
+};
 
-export interface SessionOptions {
+export type SessionOptions = {
   ttl?: number;
   data?: Record<string, unknown>;
-}
+};
 
-export interface HatagoError extends Error {
+export type HatagoError = Error & {
   code: string;
   details?: unknown;
-}
+};
 
 export type ServerType = 'stdio' | 'http' | 'sse' | 'ws';
 
 export type ServerStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
-export interface ServerInfo {
+export type ServerInfo = {
   id: string;
   name: string;
   version?: string;
   type: ServerType;
   status: ServerStatus;
-}
+};
 
-export interface ConnectionResult {
+export type ConnectionResult = {
   success: boolean;
   serverId: string;
   error?: Error;
-}
+};

--- a/packages/core/src/types/protocol.ts
+++ b/packages/core/src/types/protocol.ts
@@ -18,17 +18,17 @@ export const SUPPORTED_PROTOCOL_VERSION = '2025-06-18' as const;
 /**
  * Protocol features (simplified)
  */
-export interface ProtocolFeatures {
+export type ProtocolFeatures = {
   notifications: boolean;
   resources: boolean;
   prompts: boolean;
   tools: boolean;
-}
+};
 
 /**
  * Simplified protocol negotiation result
  */
-export interface NegotiatedProtocol {
+export type NegotiatedProtocol = {
   // Protocol version (always '2025-06-18' for now)
   protocol: string;
 
@@ -43,4 +43,4 @@ export interface NegotiatedProtocol {
 
   // Server capabilities (optional)
   capabilities?: Record<string, unknown>;
-}
+};

--- a/packages/core/src/types/registry.ts
+++ b/packages/core/src/types/registry.ts
@@ -8,29 +8,29 @@ import type { Prompt, Resource, Tool } from '@modelcontextprotocol/sdk/types.js'
 /**
  * Tool metadata for registry
  */
-export interface ToolMetadata {
+export type ToolMetadata = {
   serverId: string;
   originalName: string;
   publicName: string;
   tool: Tool;
-}
+};
 
 /**
  * Resource metadata for registry
  */
-export interface ResourceMetadata {
+export type ResourceMetadata = {
   serverId: string;
   originalUri: string;
   publicUri: string;
   resource: Resource;
-}
+};
 
 /**
  * Prompt metadata for registry
  */
-export interface PromptMetadata {
+export type PromptMetadata = {
   serverId: string;
   originalName: string;
   publicName: string;
   prompt: Prompt;
-}
+};

--- a/packages/core/src/types/server-config.ts
+++ b/packages/core/src/types/server-config.ts
@@ -34,7 +34,7 @@ export enum ServerState {
 /**
  * Idle policy configuration
  */
-export interface IdlePolicy {
+export type IdlePolicy = {
   /** Time in ms before stopping idle server (default: 300000 = 5min) */
   idleTimeoutMs?: number;
 
@@ -43,12 +43,12 @@ export interface IdlePolicy {
 
   /** When to reset activity counter */
   activityReset?: ActivityReset;
-}
+};
 
 /**
  * Timeout configuration for server operations
  */
-export interface ServerTimeouts {
+export type ServerTimeouts = {
   /** Process spawn/connection timeout in ms (default: 20000) */
   spawnTimeout?: number;
 
@@ -57,12 +57,12 @@ export interface ServerTimeouts {
 
   /** Ready state timeout in ms (default: 20000) */
   readyTimeout?: number;
-}
+};
 
 /**
  * Security configuration
  */
-export interface ServerSecurity {
+export type ServerSecurity = {
   /** Require authentication for this server */
   requireAuth?: boolean;
 
@@ -74,12 +74,12 @@ export interface ServerSecurity {
 
   /** Checksum for integrity verification */
   checksum?: string;
-}
+};
 
 /**
  * Server metadata (auto-generated, not user-editable)
  */
-export interface ServerMetadata {
+export type ServerMetadata = {
   /** Server identifier */
   serverId: string;
 
@@ -134,12 +134,12 @@ export interface ServerMetadata {
     headers?: Record<string, string>;
     lastSuccessfulPing?: string;
   };
-}
+};
 
 /**
  * Complete server configuration
  */
-export interface ServerConfigInterface {
+export type ServerConfigInterface = {
   // === Connection Configuration ===
 
   /** Local server command */
@@ -192,12 +192,12 @@ export interface ServerConfigInterface {
     timestamp: string;
     retryAfterMs?: number;
   };
-}
+};
 
 /**
  * Hatago configuration with servers
  */
-export interface ServerHatagoConfig {
+export type ServerHatagoConfig = {
   /** MCP servers configuration */
   mcpServers?: Record<string, ServerConfigInterface>;
 
@@ -220,4 +220,4 @@ export interface ServerHatagoConfig {
 
   /** Admin mode for showing manual servers */
   adminMode?: boolean;
-}
+};

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -6,9 +6,9 @@
 /**
  * Session data
  */
-export interface Session {
+export type Session = {
   id: string;
   createdAt: Date;
   lastAccessedAt: Date;
   ttlSeconds: number;
-}
+};

--- a/packages/hub/src/enhanced-hub.ts
+++ b/packages/hub/src/enhanced-hub.ts
@@ -32,7 +32,7 @@ type ExtendedServerConfig = CoreServerConfig & {
   };
 };
 
-interface ExtendedHatagoConfig {
+type ExtendedHatagoConfig = {
   version?: number;
   logLevel?: string;
   mcpServers?: Record<string, ExtendedServerConfig>;
@@ -42,7 +42,7 @@ interface ExtendedHatagoConfig {
     rateLimitSec?: number;
     severity?: string[];
   };
-}
+};
 
 // Re-export as our working types
 type ServerConfig = ExtendedServerConfig;
@@ -51,7 +51,7 @@ type HatagoConfig = ExtendedHatagoConfig;
 /**
  * Enhanced Hub options
  */
-export interface EnhancedHubOptions extends HubOptions {
+export type EnhancedHubOptions = HubOptions & {
   /** Enable management features */
   enableManagement?: boolean;
 
@@ -63,7 +63,7 @@ export interface EnhancedHubOptions extends HubOptions {
 
   /** Auto-start 'always' servers */
   autoStartAlways?: boolean;
-}
+};
 
 /**
  * Enhanced Hatago Hub with full management capabilities

--- a/packages/hub/src/enhanced-hub.ts
+++ b/packages/hub/src/enhanced-hub.ts
@@ -239,27 +239,29 @@ export class EnhancedHatagoHub extends HatagoHub {
    */
   private scheduleServerStart(serverId: string): void {
     // Start after a short delay to allow full initialization
-    setTimeout(async () => {
-      try {
-        // Use 'startup' type for always servers
-        if (!this.activationManager) {
-          throw new Error('Management features not enabled');
-        }
+    setTimeout(() => {
+      void (async () => {
+        try {
+          // Use 'startup' type for always servers
+          if (!this.activationManager) {
+            throw new Error('Management features not enabled');
+          }
 
-        const result = await this.activationManager.activate(
-          serverId,
-          { type: 'startup' },
-          'Startup activation for always policy'
-        );
+          const result = await this.activationManager.activate(
+            serverId,
+            { type: 'startup' },
+            'Startup activation for always policy'
+          );
 
-        if (!result.success) {
-          throw new Error(result.error ?? 'Activation failed');
+          if (!result.success) {
+            throw new Error(result.error ?? 'Activation failed');
+          }
+        } catch (error) {
+          this.logger.error(`Failed to auto-start server ${serverId}`, {
+            error: error instanceof Error ? error.message : String(error)
+          });
         }
-      } catch (error) {
-        this.logger.error(`Failed to auto-start server ${serverId}`, {
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
+      })();
     }, 1000);
   }
 

--- a/packages/hub/src/internal-tools.ts
+++ b/packages/hub/src/internal-tools.ts
@@ -5,12 +5,12 @@
 import { z } from 'zod';
 import type { HatagoHub } from './hub.js';
 
-export interface InternalTool<T = unknown> {
+export type InternalTool<T = unknown> = {
   name: string;
   description: string;
   inputSchema: z.ZodObject<z.ZodRawShape>;
   handler: (args: T, hub: HatagoHub) => Promise<unknown> | unknown;
-}
+};
 
 /**
  * Get internal management tools

--- a/packages/hub/src/logger.ts
+++ b/packages/hub/src/logger.ts
@@ -2,9 +2,9 @@
  * Simple logger for Hatago Hub
  */
 
-export interface LogData {
+export type LogData = {
   [key: string]: unknown;
-}
+};
 
 export class Logger {
   private debugMode: boolean;

--- a/packages/hub/src/mcp-server/activation-manager.ts
+++ b/packages/hub/src/mcp-server/activation-manager.ts
@@ -30,7 +30,7 @@ import type { ServerStateMachine } from './state-machine.js';
 /**
  * Activation request
  */
-export interface ActivationRequest {
+export type ActivationRequest = {
   serverId: string;
   reason: string;
   source: {
@@ -39,18 +39,18 @@ export interface ActivationRequest {
     sessionId?: string;
   };
   timestamp: string;
-}
+};
 
 /**
  * Activation result
  */
-export interface ActivationResult {
+export type ActivationResult = {
   success: boolean;
   serverId: string;
   state: ServerState;
   error?: string;
   duration?: number;
-}
+};
 
 /**
  * Server activation manager

--- a/packages/hub/src/mcp-server/activation-manager.ts
+++ b/packages/hub/src/mcp-server/activation-manager.ts
@@ -7,7 +7,7 @@ import type { ActivationPolicy } from '@himorishige/hatago-core';
 import { ServerState } from '@himorishige/hatago-core';
 
 // Extended server config type
-interface ServerConfig {
+type ServerConfig = {
   type?: 'http' | 'sse'; // Optional for HTTP, required for SSE
   command?: string; // For STDIO servers
   args?: string[];
@@ -22,7 +22,7 @@ interface ServerConfig {
     timestamp: string;
     retryAfterMs?: number;
   };
-}
+};
 
 import { EventEmitter } from 'node:events';
 import type { ServerStateMachine } from './state-machine.js';
@@ -434,14 +434,16 @@ export class ActivationManager extends EventEmitter {
     await this.stateMachine.transition(serverId, ServerState.ERROR, error.message);
 
     // Auto-transition to cooldown
-    setTimeout(async () => {
-      if (this.stateMachine.getState(serverId) === ServerState.ERROR) {
-        await this.stateMachine.transition(
-          serverId,
-          ServerState.COOLDOWN,
-          'Entering cooldown after error'
-        );
-      }
+    setTimeout(() => {
+      void (async () => {
+        if (this.stateMachine.getState(serverId) === ServerState.ERROR) {
+          await this.stateMachine.transition(
+            serverId,
+            ServerState.COOLDOWN,
+            'Entering cooldown after error'
+          );
+        }
+      })();
     }, 1000);
   }
 

--- a/packages/hub/src/mcp-server/hatago-management-server.ts
+++ b/packages/hub/src/mcp-server/hatago-management-server.ts
@@ -13,7 +13,7 @@ import type {
 import { ServerState } from '@himorishige/hatago-core';
 
 // Extended types for management features
-interface ServerConfig {
+type ServerConfig = {
   type?: 'http' | 'sse'; // Optional for HTTP, required for SSE
   command?: string; // For STDIO servers
   args?: string[];
@@ -29,9 +29,9 @@ interface ServerConfig {
     requestMs?: number;
     keepAliveMs?: number;
   };
-}
+};
 
-interface HatagoConfig {
+type HatagoConfig = {
   version?: number;
   logLevel?: string;
   mcpServers?: Record<string, ServerConfig>;
@@ -46,7 +46,7 @@ interface HatagoConfig {
     activationPolicy?: ActivationPolicy;
     idlePolicy?: IdlePolicy;
   };
-}
+};
 
 import { existsSync, readFileSync } from 'node:fs';
 import { AuditLogger } from '../security/audit-logger.js';
@@ -59,13 +59,13 @@ import type { ServerStateMachine } from './state-machine.js';
 /**
  * Management server options
  */
-export interface ManagementServerOptions {
+export type ManagementServerOptions = {
   configFilePath: string;
   stateMachine: ServerStateMachine;
   activationManager: ActivationManager;
   idleManager: IdleManager;
   enableAudit?: boolean;
-}
+};
 
 /**
  * Hatago Management MCP Server

--- a/packages/hub/src/mcp-server/metadata-store.ts
+++ b/packages/hub/src/mcp-server/metadata-store.ts
@@ -10,7 +10,7 @@ import type { Prompt, Resource, ServerMetadata, Tool } from '@himorishige/hatago
 /**
  * Server metadata with MCP capabilities
  */
-export interface StoredServerMetadata extends Partial<ServerMetadata> {
+export type StoredServerMetadata = Partial<ServerMetadata> & {
   /** Server identifier */
   serverId: string;
 
@@ -31,7 +31,7 @@ export interface StoredServerMetadata extends Partial<ServerMetadata> {
 
   /** Hash of prompt definitions for change detection */
   promptsHash?: string;
-}
+};
 
 /**
  * Metadata store for persistent server information

--- a/packages/hub/src/mcp-server/state-machine.ts
+++ b/packages/hub/src/mcp-server/state-machine.ts
@@ -8,13 +8,13 @@ import { ServerState } from '@himorishige/hatago-core';
 /**
  * State transition event
  */
-export interface StateTransitionEvent {
+export type StateTransitionEvent = {
   serverId: string;
   from: ServerState;
   to: ServerState;
   reason?: string;
   timestamp: string;
-}
+};
 
 /**
  * Valid state transitions

--- a/packages/hub/src/notification-manager.ts
+++ b/packages/hub/src/notification-manager.ts
@@ -10,19 +10,19 @@ import type { Logger } from './logger.js';
 export type NotificationSeverity = 'info' | 'warn' | 'error';
 export type NotificationCategory = 'config' | 'server' | 'tool';
 
-export interface NotificationEvent {
+export type NotificationEvent = {
   severity: NotificationSeverity;
   category: NotificationCategory;
   message: string;
   data?: unknown;
   timestamp: number;
-}
+};
 
-export interface NotificationConfig {
+export type NotificationConfig = {
   enabled: boolean;
   rateLimitSec: number;
   severity: NotificationSeverity[];
-}
+};
 
 /**
  * Simple notification manager with rate limiting

--- a/packages/hub/src/security/audit-logger.ts
+++ b/packages/hub/src/security/audit-logger.ts
@@ -17,7 +17,7 @@ import { resolve } from 'node:path';
 /**
  * Audit log entry
  */
-export interface AuditLogEntry {
+export type AuditLogEntry = {
   /** Unique ID for the log entry */
   id: string;
 
@@ -57,18 +57,18 @@ export interface AuditLogEntry {
 
   /** Security impact level */
   severity: 'info' | 'warning' | 'error' | 'critical';
-}
+};
 
 /**
  * Audit statistics
  */
-export interface AuditStats {
+export type AuditStats = {
   totalEvents: number;
   eventsByType: Record<string, number>;
   eventsBySeverity: Record<string, number>;
   recentEvents: AuditLogEntry[];
   lastEventTime?: string;
-}
+};
 
 /**
  * Audit logger for tracking configuration changes
@@ -233,12 +233,14 @@ export class AuditLogger {
       filtered = filtered.filter((e) => e.details.serverId === options.serverId);
     }
 
-    if (options.startTime) {
-      filtered = filtered.filter((e) => e.timestamp >= options.startTime!);
+    if (options.startTime !== undefined) {
+      const start = options.startTime;
+      filtered = filtered.filter((e) => e.timestamp >= start);
     }
 
-    if (options.endTime) {
-      filtered = filtered.filter((e) => e.timestamp <= options.endTime!);
+    if (options.endTime !== undefined) {
+      const end = options.endTime;
+      filtered = filtered.filter((e) => e.timestamp <= end);
     }
 
     // Apply limit

--- a/packages/hub/src/security/file-guard.ts
+++ b/packages/hub/src/security/file-guard.ts
@@ -10,7 +10,7 @@ import { diffLines } from 'diff';
 /**
  * Diff result for configuration changes
  */
-export interface DiffResult {
+export type DiffResult = {
   /** Text diff of changes */
   diff: string;
 
@@ -31,7 +31,7 @@ export interface DiffResult {
       to: string;
     }>;
   };
-}
+};
 
 /**
  * File access guard

--- a/packages/hub/src/sse-manager.ts
+++ b/packages/hub/src/sse-manager.ts
@@ -4,21 +4,21 @@
 
 import type { Logger } from './logger.js';
 
-export interface SSEClient {
+export type SSEClient = {
   id: string;
   writer: WritableStreamDefaultWriter;
   closed: boolean;
   keepAliveInterval?: ReturnType<typeof setInterval>;
   stream?: unknown; // For framework-specific streams
-}
+};
 
-export interface ProgressNotification {
+export type ProgressNotification = {
   progressToken: string;
   progress: number;
   total?: number;
   message?: string;
   serverId?: string;
-}
+};
 
 /**
  * SSE Manager for handling progress notifications

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -7,7 +7,7 @@ import type { Prompt, Resource, Tool, HatagoConfig } from '@himorishige/hatago-c
 /**
  * Server specification
  */
-export interface ServerSpec {
+export type ServerSpec = {
   // Local server
   command?: string;
   args?: string[];
@@ -25,12 +25,12 @@ export interface ServerSpec {
   keepAliveTimeout?: number; // Keep-alive timeout
   reconnect?: boolean;
   reconnectDelay?: number;
-}
+};
 
 /**
  * Hub options
  */
-export interface HubOptions {
+export type HubOptions = {
   configFile?: string;
   /** Preloaded configuration data. Takes precedence over configFile when provided. */
   preloadedConfig?: { path?: string; data: HatagoConfig } | undefined;
@@ -40,38 +40,38 @@ export interface HubOptions {
   namingStrategy?: 'none' | 'namespace' | 'prefix';
   separator?: string;
   tags?: string[]; // Filter servers by tags
-}
+};
 
 /**
  * Tool call options
  */
-export interface CallOptions {
+export type CallOptions = {
   timeout?: number;
   /** Session ID for multi-client support */
   sessionId?: string;
   /** @deprecated Use appropriate server routing instead */
   serverId?: string;
   signal?: AbortSignal;
-}
+};
 
 /**
  * Resource read options
  */
-export interface ReadOptions {
+export type ReadOptions = {
   timeout?: number;
   /** Session ID for multi-client support */
   sessionId?: string;
   /** @deprecated Use appropriate server routing instead */
   serverId?: string;
   signal?: AbortSignal;
-}
+};
 
 /**
  * List options
  */
-export interface ListOptions {
+export type ListOptions = {
   serverId?: string;
-}
+};
 
 /**
  * Hub event types
@@ -91,13 +91,13 @@ export type HubEvent =
 /**
  * Hub event data
  */
-export interface HubEventData {
+export type HubEventData = {
   type: HubEvent;
   serverId?: string;
   data?: unknown;
   error?: Error;
   [key: string]: unknown;
-}
+};
 
 /**
  * Hub event handler
@@ -107,7 +107,7 @@ export type HubEventHandler = (event: HubEventData) => void;
 /**
  * Connected server info
  */
-export interface ConnectedServer {
+export type ConnectedServer = {
   id: string;
   spec: ServerSpec;
   status: 'connecting' | 'connected' | 'disconnected' | 'error';
@@ -115,4 +115,4 @@ export interface ConnectedServer {
   tools: Tool[];
   resources: Resource[];
   prompts: Prompt[];
-}
+};

--- a/packages/hub/src/workers-entry.ts
+++ b/packages/hub/src/workers-entry.ts
@@ -17,14 +17,10 @@ export function createHub(options?: HubOptions): HatagoHub {
   // In simple example, we use memory storage instead
   const minimalEnv = {
     CONFIG_KV: {
-      get: async () => await Promise.resolve(null),
-      put: async () => {
-        await Promise.resolve();
-      },
-      delete: async () => {
-        await Promise.resolve();
-      },
-      list: async () => await Promise.resolve({ keys: [] })
+      get: () => null,
+      put: () => {},
+      delete: () => {},
+      list: () => ({ keys: [] })
     } as unknown
   };
 

--- a/packages/hub/src/zod-to-json-schema.ts
+++ b/packages/hub/src/zod-to-json-schema.ts
@@ -4,28 +4,28 @@
 
 import type { z } from 'zod';
 
-interface ZodDefWithShape {
+type ZodDefWithShape = {
   shape: () => Record<string, unknown>;
-}
+};
 
-interface ZodDefWithTypeName {
+type ZodDefWithTypeName = {
   typeName: string;
   description?: string;
   innerType?: {
     _def: ZodDefWithTypeName;
   };
-}
+};
 
-interface JsonSchemaProperty {
+type JsonSchemaProperty = {
   type: string;
   description?: string;
-}
+};
 
-interface JsonSchema {
+type JsonSchema = {
   type: string;
   properties: Record<string, JsonSchemaProperty>;
   required?: string[];
-}
+};
 
 /**
  * Convert Zod schema to JSON Schema (simplified)

--- a/packages/runtime/src/error-recovery/circuit-breaker.ts
+++ b/packages/runtime/src/error-recovery/circuit-breaker.ts
@@ -14,7 +14,7 @@ export enum CircuitState {
 /**
  * Circuit breaker configuration
  */
-export interface CircuitBreakerConfig {
+export type CircuitBreakerConfig = {
   /** Failure threshold to open circuit */
   failureThreshold: number;
 
@@ -29,7 +29,7 @@ export interface CircuitBreakerConfig {
 
   /** Optional callback when state changes */
   onStateChange?: (oldState: CircuitState, newState: CircuitState) => void;
-}
+};
 
 /**
  * Circuit breaker for protecting against cascading failures

--- a/packages/runtime/src/error-recovery/error-classifier.ts
+++ b/packages/runtime/src/error-recovery/error-classifier.ts
@@ -31,13 +31,13 @@ export enum ErrorSeverity {
 /**
  * Classified error information
  */
-export interface ClassifiedError {
+export type ClassifiedError = {
   type: ErrorType;
   severity: ErrorSeverity;
   retryable: boolean;
   message: string;
   originalError?: unknown;
-}
+};
 
 /**
  * Classify an error

--- a/packages/runtime/src/error-recovery/strategies.ts
+++ b/packages/runtime/src/error-recovery/strategies.ts
@@ -5,7 +5,7 @@
 /**
  * Retry strategy configuration
  */
-export interface RetryStrategy {
+export type RetryStrategy = {
   /** Maximum number of retry attempts */
   maxAttempts: number;
 
@@ -23,7 +23,7 @@ export interface RetryStrategy {
 
   /** Timeout for each attempt in milliseconds */
   attemptTimeout?: number;
-}
+};
 
 /**
  * Default retry strategies

--- a/packages/runtime/src/logger/stdio-safe-logger.ts
+++ b/packages/runtime/src/logger/stdio-safe-logger.ts
@@ -8,12 +8,12 @@
 import type { Logger, LogLevel } from '@himorishige/hatago-core';
 import { shouldLog } from '@himorishige/hatago-core';
 
-export interface StdioSafeLoggerOptions {
+export type StdioSafeLoggerOptions = {
   level?: LogLevel;
   json?: boolean;
   prefix?: string;
   file?: string | null; // For future file logging support
-}
+};
 
 export class StdioSafeLogger implements Logger {
   level: LogLevel;

--- a/packages/runtime/src/platform/node.ts
+++ b/packages/runtime/src/platform/node.ts
@@ -157,7 +157,7 @@ export function createNodePlatform(options: PlatformOptions = {}): Platform {
     },
 
     readFile: async (filePath: string): Promise<string> => {
-      return await fs.readFile(filePath, 'utf-8');
+      return fs.readFile(filePath, 'utf-8');
     },
 
     writeFile: async (filePath: string, content: string): Promise<void> => {

--- a/packages/runtime/src/platform/types.ts
+++ b/packages/runtime/src/platform/types.ts
@@ -10,40 +10,40 @@ import type { ChildProcess } from 'node:child_process';
 /**
  * Configuration storage interface
  */
-export interface ConfigStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-  delete(key: string): Promise<void>;
-  list(): Promise<string[]>;
-}
+export type ConfigStore = {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: unknown) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+  list: () => Promise<string[]>;
+};
 
 /**
  * Session storage interface
  */
-export interface SessionStore {
-  create(id: string, data: unknown): Promise<void>;
-  get(id: string): Promise<unknown>;
-  update(id: string, data: unknown): Promise<void>;
-  delete(id: string): Promise<void>;
-  exists(id: string): Promise<boolean>;
-  list(): Promise<string[]>;
-}
+export type SessionStore = {
+  create: (id: string, data: unknown) => Promise<void>;
+  get: (id: string) => Promise<unknown>;
+  update: (id: string, data: unknown) => Promise<void>;
+  delete: (id: string) => Promise<void>;
+  exists: (id: string) => Promise<boolean>;
+  list: () => Promise<string[]>;
+};
 
 /**
  * Process spawn options
  */
-export interface SpawnOptions {
+export type SpawnOptions = {
   command: string;
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;
-}
+};
 
 /**
  * Platform capabilities interface
  * Required features are always present, optional features use capability pattern
  */
-export interface Platform {
+export type Platform = {
   // Required features (available in all environments)
   randomUUID(): string;
   getEnv(key: string): string | undefined;
@@ -70,18 +70,18 @@ export interface Platform {
     hasDurableObjects: boolean;
     hasKVStorage: boolean;
   };
-}
+};
 
 /**
  * Platform initialization options
  */
-export interface PlatformOptions {
+export type PlatformOptions = {
   env?: Record<string, unknown>;
   storage?: {
     configPath?: string;
     sessionTTL?: number;
   };
-}
+};
 
 /**
  * Error thrown when attempting to use unsupported features

--- a/packages/runtime/src/platform/workers.ts
+++ b/packages/runtime/src/platform/workers.ts
@@ -12,12 +12,12 @@ import type { ConfigStore, Platform, PlatformOptions, SessionStore } from './typ
 /**
  * Cloudflare Workers environment bindings
  */
-export interface WorkersEnv {
+export type WorkersEnv = {
   CONFIG_KV: KVNamespace;
   CACHE_KV?: KVNamespace;
   SESSION_DO?: DurableObjectNamespace;
   [key: string]: unknown;
-}
+};
 
 /**
  * KV-based configuration storage for Workers
@@ -123,7 +123,7 @@ class DOSessionStore implements SessionStore {
     const stub = this.getStub(id);
     const response = await stub.fetch('https://session/get');
     if (response.ok) {
-      return await response.json();
+      return response.json();
     }
     return null;
   }
@@ -194,7 +194,7 @@ class KVSessionStore implements SessionStore {
   }
 
   async get(id: string): Promise<unknown> {
-    return await this.kv.get(`session:${id}`, { type: 'json' });
+    return this.kv.get(`session:${id}`, { type: 'json' });
   }
 
   async update(id: string, data: unknown): Promise<void> {

--- a/packages/runtime/src/registry/prompt-registry.ts
+++ b/packages/runtime/src/registry/prompt-registry.ts
@@ -8,18 +8,18 @@ import { logger } from '../utils/logger.js';
 /**
  * Prompt info with server association
  */
-export interface PromptInfo extends Prompt {
+export type PromptInfo = Prompt & {
   serverId: string;
   originalName: string;
-}
+};
 
 /**
  * Prompt metadata stored in registry
  */
-interface PromptMetadata extends Prompt {
+type PromptMetadata = Prompt & {
   serverId: string;
   originalName: string;
-}
+};
 
 /**
  * Registry for managing prompts from multiple servers
@@ -98,11 +98,13 @@ export class PromptRegistry {
    */
   getServerPrompts(serverId: string): Prompt[] {
     const promptNames = this.serverPrompts.get(serverId);
-    return promptNames
-      ? Array.from(promptNames)
-          .map((name) => this.prompts.get(name)!)
-          .filter(Boolean)
-      : [];
+    if (!promptNames) return [];
+    const result: Prompt[] = [];
+    for (const name of Array.from(promptNames)) {
+      const prompt = this.prompts.get(name);
+      if (prompt) result.push(prompt);
+    }
+    return result;
   }
 
   /**

--- a/packages/runtime/src/registry/resource-registry.ts
+++ b/packages/runtime/src/registry/resource-registry.ts
@@ -2,22 +2,22 @@ import type { Resource } from '@modelcontextprotocol/sdk/types.js';
 import { createNamingFunction, createParsingFunction } from '../utils/naming-strategy.js';
 import type { ToolNamingConfig } from './types.js';
 
-export interface ResourceMetadata extends Resource {
+export type ResourceMetadata = Resource & {
   serverId: string;
   originalUri: string;
-}
+};
 
-export interface ResourceResolveResult {
+export type ResourceResolveResult = {
   serverId: string;
   originalUri: string;
   publicUri: string;
-}
+};
 
-export interface ResourceRegistryOptions {
+export type ResourceRegistryOptions = {
   namingConfig?: ToolNamingConfig;
-}
+};
 
-export interface ResourceRegistry {
+export type ResourceRegistry = {
   registerServerResources: (serverId: string, resources: Resource[]) => void;
   clearServerResources: (serverId: string) => void;
   resolveResource: (publicUri: string) => ResourceResolveResult | null;
@@ -26,7 +26,7 @@ export interface ResourceRegistry {
   getResourceCollisions: () => Map<string, string[]>;
   getResourceCount: () => number;
   clear: () => void;
-}
+};
 
 /**
  * Create a resource registry for managing resources from multiple MCP servers

--- a/packages/runtime/src/registry/tool-registry-functional.ts
+++ b/packages/runtime/src/registry/tool-registry-functional.ts
@@ -10,11 +10,11 @@ import type { ToolNamingConfig } from './types.js';
 /**
  * Immutable registry type
  */
-export interface ToolRegistryState {
+export type ToolRegistryState = {
   readonly tools: ReadonlyMap<string, ToolMetadata>;
   readonly serverTools: ReadonlyMap<string, ReadonlySet<string>>;
   readonly namingConfig: ToolNamingConfig;
-}
+};
 
 /**
  * Create an empty registry

--- a/packages/runtime/src/registry/tool-registry.ts
+++ b/packages/runtime/src/registry/tool-registry.ts
@@ -14,15 +14,15 @@ import {
 import type { ToolNamingConfig, ToolNamingStrategy } from './types.js';
 
 // Tool name collision information
-export interface ToolCollision {
+export type ToolCollision = {
   toolName: string;
   serverIds: string[];
-}
+};
 
 // Tool registry options
-export interface ToolRegistryOptions {
+export type ToolRegistryOptions = {
   namingConfig: ToolNamingConfig;
-}
+};
 
 /**
  * Tool Registry - Tool name management and collision avoidance

--- a/packages/runtime/src/registry/types.ts
+++ b/packages/runtime/src/registry/types.ts
@@ -10,13 +10,13 @@ export type ToolNamingStrategy = 'prefix' | 'suffix' | 'none' | 'namespace' | 'e
 /**
  * Tool naming configuration
  */
-export interface ToolNamingConfig {
+export type ToolNamingConfig = {
   strategy: ToolNamingStrategy;
   separator?: string;
   serverIdInName?: boolean;
   format?: string;
   aliases?: Record<string, string>;
-}
+};
 
 /**
  * Default tool naming configuration
@@ -40,8 +40,8 @@ export type PromptNamingConfig = ToolNamingConfig;
 /**
  * Combined naming configuration
  */
-export interface NamingConfig {
+export type NamingConfig = {
   toolNaming?: ToolNamingConfig;
   resourceNaming?: ResourceNamingConfig;
   promptNaming?: PromptNamingConfig;
-}
+};

--- a/packages/runtime/src/router/router-types.ts
+++ b/packages/runtime/src/router/router-types.ts
@@ -7,22 +7,22 @@ import type { Prompt, Resource, Tool } from '@himorishige/hatago-core';
 /**
  * Target for routing decisions
  */
-export interface RouteTarget {
+export type RouteTarget = {
   serverId: string;
   originalName: string;
-}
+};
 
 /**
  * Extended target for resources with URI
  */
-export interface ResourceRouteTarget extends RouteTarget {
+export type ResourceRouteTarget = RouteTarget & {
   originalUri: string;
-}
+};
 
 /**
  * Routing decision result
  */
-export interface RouteDecision<T = RouteTarget> {
+export type RouteDecision<T = RouteTarget> = {
   found: boolean;
   target: T | null;
   error?: string;
@@ -30,21 +30,21 @@ export interface RouteDecision<T = RouteTarget> {
     publicName?: string;
     resolvedBy?: string;
   };
-}
+};
 
 /**
  * Context for routing decisions
  */
-export interface RouterContext {
+export type RouterContext = {
   sessionId?: string;
   serverId?: string;
   debug?: boolean;
-}
+};
 
 /**
  * Router configuration
  */
-export interface RouterConfig {
+export type RouterConfig = {
   /** Naming strategy for tools/resources/prompts */
   namingStrategy?: 'prefix' | 'suffix' | 'namespace' | 'none';
 
@@ -53,25 +53,25 @@ export interface RouterConfig {
 
   /** Enable debug logging */
   debug?: boolean;
-}
+};
 
 /**
  * Registry interfaces for router
  */
-export interface ToolRegistryInterface {
-  resolveTool(publicName: string): RouteTarget | null;
-  getAllTools(): Tool[];
-  getServerTools(serverId: string): Tool[];
-}
+export type ToolRegistryInterface = {
+  resolveTool: (publicName: string) => RouteTarget | null;
+  getAllTools: () => Tool[];
+  getServerTools: (serverId: string) => Tool[];
+};
 
-export interface ResourceRegistryInterface {
-  resolveResource(publicUri: string): ResourceRouteTarget | null;
-  getAllResources(): Resource[];
-  getServerResources(serverId: string): Resource[];
-}
+export type ResourceRegistryInterface = {
+  resolveResource: (publicUri: string) => ResourceRouteTarget | null;
+  getAllResources: () => Resource[];
+  getServerResources: (serverId: string) => Resource[];
+};
 
-export interface PromptRegistryInterface {
-  resolvePrompt(publicName: string): RouteTarget | null;
-  getAllPrompts(): Prompt[];
-  getServerPrompts(serverId: string): Prompt[];
-}
+export type PromptRegistryInterface = {
+  resolvePrompt: (publicName: string) => RouteTarget | null;
+  getAllPrompts: () => Prompt[];
+  getServerPrompts: (serverId: string) => Prompt[];
+};

--- a/packages/runtime/src/session/operations.ts
+++ b/packages/runtime/src/session/operations.ts
@@ -8,10 +8,10 @@ import type { Session } from '@himorishige/hatago-core';
 /**
  * Immutable session store type
  */
-export interface SessionState {
+export type SessionState = {
   readonly sessions: ReadonlyMap<string, Session>;
   readonly ttlSeconds: number;
-}
+};
 
 /**
  * Create an empty session state
@@ -208,10 +208,10 @@ export function clearSessions(state: SessionState): SessionState {
 /**
  * Batch operations for efficiency
  */
-export interface SessionOperation {
+export type SessionOperation = {
   type: 'create' | 'touch' | 'delete';
   sessionId: string;
-}
+};
 
 /**
  * Apply multiple operations in a single pass
@@ -243,12 +243,12 @@ export function applyOperations(
 /**
  * Session statistics
  */
-export interface SessionStats {
+export type SessionStats = {
   total: number;
   active: number;
   expired: number;
   averageAgeSeconds: number;
-}
+};
 
 /**
  * Get session statistics

--- a/packages/runtime/src/tool-invoker/types.ts
+++ b/packages/runtime/src/tool-invoker/types.ts
@@ -17,7 +17,7 @@ export type ToolHandler = (args: unknown, progressCallback?: ProgressCallback) =
 /**
  * Tool call result
  */
-export interface ToolCallResult {
+export type ToolCallResult = {
   content?: Array<{
     type: 'text' | 'image' | 'resource';
     text?: string;
@@ -25,21 +25,21 @@ export interface ToolCallResult {
     mimeType?: string;
   }>;
   isError?: boolean;
-}
+};
 
 /**
  * Tool with handler
  */
-export interface ToolWithHandler extends Tool {
+export type ToolWithHandler = Tool & {
   handler: ToolHandler;
-}
+};
 
 /**
  * Tool Invoker options
  */
-export interface ToolInvokerOptions {
+export type ToolInvokerOptions = {
   timeout?: number;
   retryCount?: number;
   retryDelay?: number;
   progressToken?: string;
-}
+};

--- a/packages/runtime/src/utils/logger.ts
+++ b/packages/runtime/src/utils/logger.ts
@@ -4,12 +4,12 @@
 
 import { getPlatform, isPlatformInitialized } from '../platform/index.js';
 
-export interface Logger {
+export type Logger = {
   debug: (message: string, ...args: unknown[]) => void;
   info: (message: string, ...args: unknown[]) => void;
   warn: (message: string, ...args: unknown[]) => void;
   error: (message: string, ...args: unknown[]) => void;
-}
+};
 
 /**
  * Check if debug mode is enabled

--- a/packages/runtime/src/utils/result.ts
+++ b/packages/runtime/src/utils/result.ts
@@ -8,18 +8,18 @@ import type { HatagoError } from './errors.js';
 /**
  * Success result
  */
-export interface Ok<T> {
+export type Ok<T> = {
   readonly ok: true;
   readonly value: T;
-}
+};
 
 /**
  * Error result
  */
-export interface Err<E = HatagoError> {
+export type Err<E = HatagoError> = {
   readonly ok: false;
   readonly error: E;
-}
+};
 
 /**
  * Result type - Either Ok or Err
@@ -92,7 +92,11 @@ export const unwrap = <T, E>(result: Result<T, E>): T => {
   if (isOk(result)) {
     return result.value;
   }
-  throw result.error;
+  const err = result.error as unknown;
+  if (err instanceof Error) {
+    throw err;
+  }
+  throw new Error(typeof err === 'string' ? err : JSON.stringify(err));
 };
 
 /**

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -13,14 +13,14 @@ import { cors } from 'hono/cors';
 import type { Logger } from './logger.js';
 import type { HatagoConfig } from '@himorishige/hatago-core';
 
-interface HttpOptions {
+type HttpOptions = {
   config: { path?: string; data: HatagoConfig };
   host: string;
   port: number;
   logger: Logger;
   watchConfig?: boolean;
   tags?: string[];
-}
+};
 
 /**
  * Start the MCP server in HTTP mode
@@ -97,6 +97,10 @@ export async function startHttp(options: HttpOptions): Promise<void> {
     }
   };
 
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+  process.on('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,7 +18,7 @@ export { generateDefaultConfig } from './utils.js';
 /**
  * Server options for starting the MCP Hub
  */
-export interface ServerOptions {
+export type ServerOptions = {
   mode?: 'stdio' | 'http';
   config?: string;
   host?: string;
@@ -28,7 +28,7 @@ export interface ServerOptions {
   quiet?: boolean;
   watchConfig?: boolean;
   tags?: string[];
-}
+};
 
 /**
  * Start the MCP Hub server with the given options

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -5,11 +5,11 @@
 /**
  * Parsed command-line arguments
  */
-export interface ParsedArgs {
+export type ParsedArgs = {
   command?: string;
   flags: Record<string, string | boolean>;
   positional: string[];
-}
+};
 
 /**
  * Simple command-line argument parser with command support

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -1,13 +1,13 @@
 import type { HatagoConfig } from '@himorishige/hatago-core/schemas';
 import type { HatagoHub } from '@himorishige/hatago-hub';
 
-export interface HubTestOptions {
+export type HubTestOptions = {
   config?: Partial<HatagoConfig>;
   timeout?: number;
   verbose?: boolean;
-}
+};
 
-export interface FixtureOptions {
+export type FixtureOptions = {
   type: 'stdio' | 'http' | 'sse';
   port?: number;
   features?: {
@@ -17,24 +17,24 @@ export interface FixtureOptions {
     fail?: boolean;
     resources?: boolean;
   };
-}
+};
 
-export interface WaitForOptions {
+export type WaitForOptions = {
   timeout?: number;
   interval?: number;
   errorMessage?: string;
-}
+};
 
-export interface TestFixture {
+export type TestFixture = {
   type: 'stdio' | 'http' | 'sse';
   port?: number;
   command?: string;
   args?: string[];
   url?: string;
   cleanup: () => Promise<void>;
-}
+};
 
-export interface TestContext {
+export type TestContext = {
   hub: HatagoHub;
   fixture: TestFixture;
-}
+};

--- a/packages/transport/src/streamable-http/streamable-http-transport.ts
+++ b/packages/transport/src/streamable-http/streamable-http-transport.ts
@@ -17,28 +17,28 @@ import {
   isJSONRPCResponse
 } from '@modelcontextprotocol/sdk/types.js';
 
-export interface StreamableHTTPTransportOptions {
+export type StreamableHTTPTransportOptions = {
   sessionIdGenerator?: () => string;
   enableJsonResponse?: boolean;
   onsessioninitialized?: (sessionId: string) => void;
   onsessionclosed?: (sessionId: string) => void;
   // Heartbeat interval (milliseconds) for SSE keepalive. Default: 30000ms
   keepAliveMs?: number;
-}
+};
 
-export interface SSEStream {
+export type SSEStream = {
   closed: boolean;
   close: () => Promise<void>;
   write: (data: string) => Promise<void>;
   onAbort?: (callback: () => void) => void;
-}
+};
 
-interface StreamData {
+type StreamData = {
   stream: SSEStream;
   createdAt: number;
   resolveResponse?: () => void;
   keepaliveInterval?: ReturnType<typeof setInterval>;
-}
+};
 
 export class StreamableHTTPTransport implements Transport {
   private started = false;
@@ -274,12 +274,14 @@ export class StreamableHTTPTransport implements Transport {
     }
 
     // Set up keepalive
-    const keepaliveInterval = setInterval(async () => {
-      try {
-        await sseStream.write(':heartbeat\n\n');
-      } catch {
-        clearInterval(keepaliveInterval);
-      }
+    const keepaliveInterval = setInterval(() => {
+      void (async () => {
+        try {
+          await sseStream.write(':heartbeat\n\n');
+        } catch {
+          clearInterval(keepaliveInterval);
+        }
+      })();
     }, this.keepAliveMs);
 
     // Store stream data

--- a/packages/transport/src/types.ts
+++ b/packages/transport/src/types.ts
@@ -5,7 +5,7 @@
 /**
  * Base transport interface for MCP communication
  */
-export interface ITransport {
+export type ITransport = {
   /**
    * Send a message through the transport
    */
@@ -35,49 +35,49 @@ export interface ITransport {
    * Check if transport is ready
    */
   ready(): Promise<boolean>;
-}
+};
 
 /**
  * Transport options
  */
-export interface TransportOptions {
+export type TransportOptions = {
   timeout?: number;
   reconnect?: boolean;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
-}
+};
 
 /**
  * Process transport options (Node.js)
  */
-export interface ProcessTransportOptions extends TransportOptions {
+export type ProcessTransportOptions = TransportOptions & {
   command: string;
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;
-}
+};
 
 /**
  * HTTP transport options
  */
-export interface HttpTransportOptions extends TransportOptions {
+export type HttpTransportOptions = TransportOptions & {
   url: string;
   headers?: Record<string, string>;
   method?: 'GET' | 'POST';
-}
+};
 
 /**
  * WebSocket transport options
  */
-export interface WebSocketTransportOptions extends TransportOptions {
+export type WebSocketTransportOptions = TransportOptions & {
   url: string;
   protocols?: string[];
   headers?: Record<string, string>;
-}
+};
 
 /**
  * Transport factory for creating transports based on configuration
  */
-export interface ITransportFactory {
-  createTransport(type: string, options: unknown): ITransport;
-}
+export type ITransportFactory = {
+  createTransport: (type: string, options: unknown) => ITransport;
+};


### PR DESCRIPTION
## Summary

Tighten TypeScript/ESLint rules and eliminate unsafe patterns; make STDIO require config while HTTP allows empty config; update docs accordingly.

## Changes

- Interfaces→types across server/transport/hub/runtime/test-utils.
- Async callback guards: wrap setTimeout/Interval and event callbacks with void (async () => {...})().
- return-await: apply in try/catch paths; remove unnecessary return-awaits elsewhere.
- only-throw-error: normalize throws to Error objects; fix unwrap in result.ts.
- STDIO/HTTP: enforce preflight in CLI; server guards to avoid ENOENT; HTTP permits empty preloaded config.
- Docs: README/README.ja.md/packages/mcp-hub/README.md clarify STDIO requires --config; HTTP can start without it.
- Validation:
      - pnpm format → OK
      - pnpm -r typecheck → OK
      - pnpm lint → 0 errors, 0 warnings
- Backwards Compatibility: No API-breaking changes; behavior change limited to requiring --config for STDIO mode.
- Security/Secrets: Ensure .mc2.json, .mcp.json, claude-with-everything.config.json are ignored; none are present.

## Testing

- [ ] Unit tests added/updated
- [ ] Build, typecheck, lint pass locally

## Checklist

- [x] Follows Conventional Commits
- [x] Updates docs/examples as needed
- [x] No secrets or sensitive data committed
