### PR TITLE
chore(phase2): enforce no-non-null-assertion + add test:forks + HTTP/STDIO smoke test

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,7 @@ export default tseslint.config(
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       '@typescript-eslint/only-throw-error': 'error',
       '@typescript-eslint/return-await': ['error', 'in-try-catch'],
-      '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-non-null-assertion': 'error',
 
       // Phase 1 additions (mostly auto-fixable or low-risk)
       '@typescript-eslint/no-useless-empty-export': 'error',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check": "pnpm format:check && pnpm lint && pnpm -r run typecheck",
     "typecheck": "pnpm -r run typecheck",
     "test": "pnpm -r run test",
+    "test:forks": "pnpm -r --filter @himorishige/hatago-* run test:forks",
     "serve:http": "pnpm -C packages/mcp-hub serve:http",
     "serve:stdio": "pnpm -C packages/mcp-hub serve:stdio"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "format": "prettier --write ./src",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -32,6 +32,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "test:watch": "vitest",
     "test:node": "vitest run --config vitest.config.ts",
     "test:workers": "vitest run --config vitest.config.workers.ts",

--- a/packages/mcp-hub/package.json
+++ b/packages/mcp-hub/package.json
@@ -47,6 +47,7 @@
     "postpack": "node scripts/restore-package.js",
     "prepublishOnly": "pnpm build",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write ./src",
     "lint": "eslint ./src"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -33,6 +33,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
     "build:schema": "tsx scripts/generate-schema.ts",
     "dev": "tsdown --watch",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "format": "prettier --write ./src",

--- a/packages/server/src/e2e/http.health.e2e.test.ts
+++ b/packages/server/src/e2e/http.health.e2e.test.ts
@@ -1,0 +1,71 @@
+/**
+ * HTTP /health smoke test (no real socket bind)
+ * - Mocks @hono/node-server.serve to capture the fetch handler
+ * - Calls the handler directly for GET /health
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from '../logger.js';
+
+// Capture point for the fetch handler passed to serve()
+let capturedFetch: ((req: Request) => Promise<Response>) | undefined;
+
+// Mock @hono/node-server to avoid opening a real port
+vi.mock('@hono/node-server', async () => {
+  return {
+    serve: (opts: {
+      fetch: (req: Request) => Promise<Response>;
+      port: number;
+      hostname: string;
+    }) => {
+      capturedFetch = opts.fetch;
+      // Minimal server-like object with address() and close()
+      return {
+        address() {
+          return {
+            port: opts.port,
+            address: opts.hostname
+          } as unknown as import('node:net').AddressInfo;
+        },
+        close(cb?: (err?: Error) => void) {
+          if (cb) cb();
+        }
+      };
+    }
+  };
+});
+
+// Import after mocking
+const { startHttp } = await import('../http.js');
+const { Logger: ServerLogger } = await import('../logger.js');
+
+describe('server/http /health (smoke)', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    capturedFetch = undefined;
+    logger = new ServerLogger('silent');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns healthy JSON at /health', async () => {
+    await startHttp({
+      config: { path: 'ignored.json', data: { mcpServers: {} } as any },
+      host: '127.0.0.1',
+      port: 0,
+      logger,
+      watchConfig: false
+    });
+
+    expect(capturedFetch).toBeTypeOf('function');
+
+    const res = await capturedFetch!(new Request('http://local/health'));
+    expect(res.ok).toBe(true);
+    const json = (await res.json()) as any;
+    expect(json.status).toBe('healthy');
+    expect(json.mode).toBe('http');
+  });
+});

--- a/packages/server/src/e2e/stdio.guard.e2e.test.ts
+++ b/packages/server/src/e2e/stdio.guard.e2e.test.ts
@@ -1,0 +1,19 @@
+/**
+ * STDIO guard smoke test
+ * - Verifies that startServer in STDIO mode rejects when config file is missing
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { startServer } from '../index.js';
+
+describe('server/stdio config guard (smoke)', () => {
+  it('throws ENOENT when config file does not exist', async () => {
+    // Use a surely-nonexistent path
+    const missingPath = `./__definitely_missing__/hatago.config.${Date.now()}.json`;
+
+    await expect(
+      startServer({ mode: 'stdio', config: missingPath, logLevel: 'silent' })
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "test": "vitest run",
+    "test:forks": "vitest run --pool=forks",
     "test:watch": "vitest",
     "format": "prettier --write ./src",
     "lint": "eslint ./src"


### PR DESCRIPTION
## Summary

- Enforce @typescript-eslint/no-non-null-assertion as error to prevent unsafe patterns.
- Add test:forks scripts across packages and a root aggregator to improve test stability in CI
  (uses Vitest --pool=forks).
- Add minimal server e2e smoke tests:
- http.health.e2e.test.ts: mocks @hono/node-server and asserts GET /health returns healthy JSON.
- stdio.guard.e2e.test.ts: verifies STDIO mode rejects when a non-existent config path is provided (expects ENOENT).

## Changes

-

## Testing

- [ ] Unit tests added/updated
- [ ] Build, typecheck, lint pass locally

## Checklist

- [ ] Follows Conventional Commits
- [ ] Updates docs/examples as needed
- [ ] No secrets or sensitive data committed
