### PR TITLE
chore: Update documentation and examples to reflect transport changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,20 +236,18 @@ server.registerTool('tool_name', { inputSchema: z.object({ p: z.string() }) }, h
   - 対象: `packages/mcp-hub` → `@himorishige/hatago-mcp-hub`
   - 事前手順: `pnpm -r build && pnpm -r test && pnpm -r typecheck`
   - 公開: `cd packages/mcp-hub && npm publish --access public`
-- 詳細な手順は `docs/release-guide.ja.md` を参照してください。
 
 ## ドキュメント方針
 
 - 基本は日本語の丁寧語で記載します（キャラクター口調は使用しません）。
-- 英語版が必要な場合は内容を揃えて併記します（例: `docs/release-guide.md`）。
+- 英語版が必要な場合は内容を揃えて併記します。
 - 見出しは簡潔にし、まず手順やコード例を提示します。
 
 関連ドキュメント（抜粋）:
 
-- アーキテクチャ: `docs/ARCHITECTURE.md`, `docs/hub-architecture-deep-dive.md`
-- 設定ガイド: `docs/configuration.md`, `docs/mcp-config-examples.md`
-- 比較/設計思想: `docs/comparison-cipher-hatago.md`
-- 進捗通知: `docs/PROGRESS_NOTIFICATIONS.md`
+- アーキテクチャ: `docs/ARCHITECTURE.md`, `docs/refactoring/hub-slim-plan.md`
+- 設定ガイド: `docs/configuration.md`
+- パッケージREADME: `packages/mcp-hub/README.md`
 - ユースケース: `docs/use-cases/team-development.md`
 
 ## OSS 必須ファイル（整備済み）
@@ -264,10 +262,9 @@ server.registerTool('tool_name', { inputSchema: z.object({ p: z.string() }) }, h
 
 ## 参考ドキュメント
 
-- アーキテクチャ: `docs/ARCHITECTURE.md`, `docs/hub-architecture-deep-dive.md`
-- 設定ガイド: `docs/configuration.md`, `docs/mcp-config-examples.md`
-- 進捗通知: `docs/PROGRESS_NOTIFICATIONS.md`
-- リリース運用: `docs/release-guide.ja.md` / `docs/release-guide.md`
+- アーキテクチャ: `docs/ARCHITECTURE.md`, `docs/refactoring/hub-slim-plan.md`
+- 設定ガイド: `docs/configuration.md`
+- ユースケース: `docs/use-cases/team-development.md`
 
 ## 環境依存ユーティリティの方針
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,15 @@ Hatago MCP Hub is a lightweight MCP (Model Context Protocol) hub server that man
 │   ├── server/         # Server implementation (@himorishige/hatago-server)
 │   │   ├── src/
 │   │   │   ├── index.ts      # API exports (startServer, generateDefaultConfig)
-│   │   │   ├── server.ts     # Main server implementation
+│   │   │   ├── http.ts       # HTTP mode
+│   │   │   ├── stdio.ts      # STDIO mode
 │   │   │   ├── config.ts     # Configuration management
 │   │   │   └── utils.ts      # Utilities
 │   │   └── package.json
 │   │
 │   ├── hub/            # Hub core (@himorishige/hatago-hub)
 │   │   ├── src/
-│   │   │   ├── hub.ts              # Main hub (~500 lines)
+│   │   │   ├── hub.ts              # Main hub (thin orchestrator)
 │   │   │   ├── types.ts            # Core types
 │   │   │   └── ...
 │   │   └── package.json
@@ -264,11 +265,6 @@ pnpm check  # Runs format + lint + typecheck
 ```
 
 ## Version History
-
-### v0.0.2 (Development)
-
-- Tag-based server filtering for profile management
-- Support for Japanese tags in configuration
 
 ### v0.0.2 (Current)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,7 +10,7 @@ The project is a TypeScript monorepo managed with `pnpm`. It is designed to be m
 
 Key features include:
 
-- **Multi-transport support:** STDIO, HTTP, SSE, and WebSockets.
+- **Multi-transport support:** STDIO, HTTP, and SSE.
 - **Dynamic server management:** Add, remove, and manage MCP servers on the fly.
 - **Hot-reloading:** Automatically reloads the configuration when the `hatago.config.json` file changes.
 - **Progress notifications:** Real-time progress updates for long-running operations.

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ Hatago MCP Hubは、複数のMCP（Model Context Protocol）サーバーを統�
 
 ### 🔌 豊富な接続性
 
-- **マルチトランスポート対応** - STDIO / HTTP / SSE / WebSocket
+- **マルチトランスポート対応** - STDIO / HTTP / SSE
 - **リモートMCPプロキシ** - HTTPベースのMCPサーバーへの透過的な接続
 - **NPXサーバー統合** - npmパッケージのMCPサーバーを動的に管理
 
@@ -389,7 +389,7 @@ HATAGO_METRICS=1 hatago serve --http --port 3535
 
 ### 🔧 開発者向け
 
-- [**アーキテクチャガイド**](docs/architecture.md) - システム設計とプラットフォーム抽象化
+- [**アーキテクチャガイド**](docs/ARCHITECTURE.md) - システム設計とプラットフォーム抽象化
 - [**チーム開発ユースケース**](docs/use-cases/team-development.md) - 継承機能を使ったチーム開発環境の構築
 
 ## 🏗️ アーキテクチャ

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hatago MCP Hub is a lightweight hub server that provides unified management for 
 
 ### 🔌 Rich Connectivity
 
-- **Multi-Transport Support** - STDIO / HTTP / SSE / WebSocket
+- **Multi-Transport Support** - STDIO / HTTP / SSE
 - **Remote MCP Proxy** - Transparent connection to HTTP-based MCP servers
 - **NPX Server Integration** - Dynamic management of npm package MCP servers
 
@@ -499,7 +499,7 @@ hatago status
 ## 📚 Documentation
 
 - [Configuration Guide](./docs/configuration.md)
-- [Architecture Overview](./docs/architecture.md)
+- [Architecture Overview](./docs/ARCHITECTURE.md)
 - [API Reference](./docs/api.md)
 - [Team Development Use Cases](./docs/use-cases/team-development.md)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,9 +32,9 @@ Hatago MCP Hub is a lightweight, modular hub server that manages multiple MCP (M
 │  ┌──────────────────────────────────────────────────┐  │
 │  │            Transport Layer                       │  │
 │  │                                                   │  │
-│  │  ┌──────┐ ┌──────┐ ┌─────┐ ┌──────────┐       │  │
-│  │  │STDIO │ │HTTP  │ │SSE  │ │WebSocket │       │  │
-│  │  └──────┘ └──────┘ └─────┘ └──────────┘       │  │
+│  │  ┌──────┐ ┌──────┐ ┌─────┐                 │  │
+│  │  │STDIO │ │HTTP  │ │SSE  │                 │  │
+│  │  └──────┘ └──────┘ └─────┘                 │  │
 │  └──────────────────────────────────────────────────┘  │
 └────────────────────┬────────────────────────────────────┘
                      │
@@ -87,7 +87,7 @@ hatago-mcp-hub/
 
 ### Hub (`packages/hub/src/hub.ts`)
 
-The central coordinator for all MCP operations. Simplified to ~500 lines from 1000+ lines.
+The central coordinator for all MCP operations. Thin orchestrator with responsibilities extracted into focused modules.
 
 **Key Responsibilities:**
 
@@ -175,11 +175,6 @@ Provides session isolation for multiple concurrent AI clients.
    - Server-Sent Events for streaming
    - Real-time notifications
    - Progress updates
-
-4. **WebSocket** (`packages/transport/src/websocket/`)
-   - Full-duplex communication
-   - Low-latency operations
-   - Real-time bidirectional messaging
 
 ## Configuration System
 

--- a/examples/node-example/README.md
+++ b/examples/node-example/README.md
@@ -95,4 +95,3 @@ In Node.js, all capabilities are available:
 - ✅ Local process spawning
 - ✅ File system access
 - ✅ Network requests
-- ✅ WebSocket connections

--- a/examples/workers-simple-example/README.md
+++ b/examples/workers-simple-example/README.md
@@ -127,7 +127,7 @@ Request → Cloudflare Worker
 - Progress通知のサポート
 - セッション状態の永続化（KV/Durable Objects）
 - 環境変数による動的設定
-- WebSocket/SSEによるリアルタイム通信
+- SSEによるリアルタイム通知
 
 ## 🐛 トラブルシューティング
 

--- a/packages/mcp-hub/README.md
+++ b/packages/mcp-hub/README.md
@@ -288,7 +288,7 @@ Example:
 - **Unified Interface**: Single endpoint for multiple MCP servers
 - **Tool Name Management**: Automatic collision avoidance with prefixing
 - **Session Management**: Independent sessions for multiple AI clients
-- **Multi-Transport**: STDIO, HTTP, SSE, WebSocket support
+- **Multi-Transport**: STDIO, HTTP, SSE support
 
 ### 🔄 Dynamic Updates
 

--- a/packages/runtime/examples/docs-backup/architecture.md
+++ b/packages/runtime/examples/docs-backup/architecture.md
@@ -48,12 +48,12 @@ interface Platform {
 
 ### ランタイムケイパビリティ
 
-| ランタイム | ファイルシステム | 子プロセス | TCPソケット | WebSocket | MCP種別            |
-| ---------- | ---------------- | ---------- | ----------- | --------- | ------------------ |
-| Node.js    | ✅               | ✅         | ✅          | ✅        | local, npx, remote |
-| Workers    | ❌               | ❌         | ❌          | ✅        | remoteのみ         |
-| Deno       | ✅               | ✅         | ✅          | ✅        | local, npx, remote |
-| Bun        | ✅               | ✅         | ✅          | ✅        | local, npx, remote |
+| ランタイム | ファイルシステム | 子プロセス | TCPソケット | MCP種別            |
+| ---------- | ---------------- | ---------- | ----------- | ------------------ |
+| Node.js    | ✅               | ✅         | ✅          | local, npx, remote |
+| Workers    | ❌               | ❌         | ❌          | remoteのみ         |
+| Deno       | ✅               | ✅         | ✅          | local, npx, remote |
+| Bun        | ✅               | ✅         | ✅          | local, npx, remote |
 
 ### 実装状況
 
@@ -215,7 +215,7 @@ const hub = new McpHub(platform);
 ### リモートサーバー
 
 - **実行**: ネットワーク接続
-- **トランスポート**: HTTP/SSE/WebSocket
+- **トランスポート**: HTTP/SSE
 - **ユースケース**: クラウドホストのMCPサービス
 
 ## 設計原則

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -1,28 +1,29 @@
-# @hatago/transport
+# @himorishige/hatago-transport
 
 Transport layer implementations for Hatago MCP Hub.
 
 ## Features
 
-- **STDIO Transport**: Standard input/output communication
-- **HTTP/SSE Transport**: HTTP with Server-Sent Events
-- **WebSocket Transport**: Real-time bidirectional communication
-- **Connection Management**: Robust connection handling with retry logic
+- **STDIO Client (Node.js)**: Process/stdio transport for local or NPX servers
+- **HTTP (StreamableHTTP) Server**: Server-side transport for JSON-RPC over HTTP with streaming
+- **SSE Client (re-export)**: Convenience re-export of MCP SDK's SSE client transport
+
+> Note: HTTP client transports are provided by the MCP SDK. This package focuses on server-side StreamableHTTP and stdio client for Node.js.
 
 ## Installation
 
 ```bash
-npm install @hatago/transport
+npm install @himorishige/hatago-transport
 ```
 
 ## Usage
 
-### STDIO Transport
+### STDIO Client (Node.js)
 
 ```typescript
-import { createStdioTransport } from '@hatago/transport';
+import { StdioClientTransport } from '@himorishige/hatago-transport/stdio';
 
-const transport = await createStdioTransport({
+const transport = new StdioClientTransport({
   command: 'node',
   args: ['./mcp-server.js'],
   env: process.env
@@ -31,48 +32,39 @@ const transport = await createStdioTransport({
 await transport.connect();
 ```
 
-### HTTP/SSE Transport
+### SSE Client (re-export)
 
 ```typescript
-import { createHttpTransport } from '@hatago/transport';
+import { SSEClientTransport } from '@himorishige/hatago-transport';
 
-const transport = createHttpTransport({
-  url: 'http://localhost:3000',
-  sessionId: 'my-session'
-});
-
+const transport = new SSEClientTransport(new URL('http://localhost:3000/sse'));
 await transport.connect();
 ```
 
-### WebSocket Transport
+### StreamableHTTP Server (for hubs)
 
 ```typescript
-import { createWebSocketTransport } from '@hatago/transport';
+import { StreamableHTTPTransport } from '@himorishige/hatago-transport';
 
-const transport = createWebSocketTransport({
-  url: 'ws://localhost:3000',
-  reconnect: true,
-  reconnectInterval: 5000
-});
+const http = new StreamableHTTPTransport({ enableJsonResponse: true });
+await http.start();
 
-await transport.connect();
+http.onmessage = async (message) => {
+  // handle JSON-RPC and respond using http.send(...)
+};
 ```
 
-## API
+## Types
 
-### Transport Interface
+This package exposes a minimal transport surface compatible with the MCP SDK.
 
-All transports implement the common `Transport` interface:
-
-```typescript
-interface Transport {
-  connect(): Promise<void>;
-  disconnect(): Promise<void>;
-  send(message: any): Promise<void>;
-  onMessage(handler: (message: any) => void): void;
-  onError(handler: (error: Error) => void): void;
-  onClose(handler: () => void): void;
-}
+```ts
+export type {
+  ITransport,
+  HttpTransportOptions,
+  WebSocketTransportOptions,
+  TransportOptions
+} from '@himorishige/hatago-transport';
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Update documentation and examples to reflect transport changes

## Changes

- AGENTS.md: Removed reference to WebSocket in transport instructions.
- CLAUDE.md: Updated server implementation details for clarity.
- GEMINI.md: Removed WebSocket from multi-transport support.
- README.ja.md: Updated multi-transport support to exclude WebSocket.
- README.md: Updated multi-transport support to exclude WebSocket.
- ARCHITECTURE.md: Updated transport layer diagram to exclude WebSocket.
- examples/node-example/README.md: Removed WebSocket connections from capabilities.
- examples/workers-simple-example/README.md: Changed WebSocket/SSE to SSE for real-time notifications.
- packages/mcp-hub/README.md: Updated multi-transport support to exclude WebSocket.
- packages/runtime/examples/docs-backup/architecture.md: Updated transport details to exclude WebSocket.
- packages/transport/README.md: Updated transport descriptions and package name.

## Testing

- [ ] Unit tests added/updated
- [ ] Build, typecheck, lint pass locally

## Checklist

- [ ] Follows Conventional Commits
- [ ] Updates docs/examples as needed
- [ ] No secrets or sensitive data committed
