### PR TITLE
Release v0.0.11

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -22,7 +22,7 @@ Usage:
 ```bash
 node bench/stdio-compare.mjs \
   --config /absolute/path/to/hatago.config.json \
-  --npm 0.0.10 \
+  --npm 0.0.11 \
   --iters 200 \
   [--env-file /path/to/.env]
 ```
@@ -62,11 +62,11 @@ Example calls
 
 ```bash
 # Pure hub (no servers)
-node bench/stdio-compare.mjs --config bench/configs/hatago-empty.config.json --npm 0.0.10 --iters 200
+node bench/stdio-compare.mjs --config bench/configs/hatago-empty.config.json --npm 0.0.11 --iters 200
 
 # Deterministic (local fixture)
-node bench/stdio-compare.mjs --config bench/configs/hatago-fixture.config.json --npm 0.0.10 --iters 200
+node bench/stdio-compare.mjs --config bench/configs/hatago-fixture.config.json --npm 0.0.11 --iters 200
 
 # Realistic (npx everything)
-node bench/stdio-compare.mjs --config bench/configs/hatago-everything.config.json --npm 0.0.10 --iters 200
+node bench/stdio-compare.mjs --config bench/configs/hatago-everything.config.json --npm 0.0.11 --iters 200
 ```

--- a/bench/stdio-compare.mjs
+++ b/bench/stdio-compare.mjs
@@ -23,11 +23,11 @@ async function loadCoreConstants() {
     const ver = /export const HATAGO_VERSION\s*=\s*['"]([^'"]+)['"]/m.exec(text)?.[1];
     const proto = /export const HATAGO_PROTOCOL_VERSION\s*=\s*['"]([^'"]+)['"]/m.exec(text)?.[1];
     return {
-      version: ver ?? '0.0.10',
+      version: ver ?? '0.0.11',
       protocolVersion: proto ?? '2025-06-18'
     };
   } catch {
-    return { version: '0.0.10', protocolVersion: '2025-06-18' };
+    return { version: '0.0.11', protocolVersion: '2025-06-18' };
   }
 }
 

--- a/examples/node-example/package.json
+++ b/examples/node-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatago-node-example",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Minimal Node.js example for Hatago MCP Hub",
   "type": "module",
   "scripts": {

--- a/examples/workers-example/package.json
+++ b/examples/workers-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatago-workers-example",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Minimal Cloudflare Workers example for Hatago MCP Hub",
   "type": "module",
   "scripts": {

--- a/examples/workers-simple-example/package.json
+++ b/examples/workers-simple-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatago-workers-simple-example",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Minimal Cloudflare Workers example for Hatago MCP Hub (without progress notifications)",
   "type": "module",
   "scripts": {

--- a/examples/workers-simple-example/src/index.ts
+++ b/examples/workers-simple-example/src/index.ts
@@ -45,7 +45,7 @@ app.get('/health', (c) => {
 app.get('/', (c) => {
   return c.json({
     name: 'Hatago MCP Hub - Simple Worker',
-    version: '0.0.10',
+    version: '0.0.11',
     description: 'Minimal MCP Hub server running on Cloudflare Workers',
     endpoints: {
       '/': 'This information',

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:forks": "pnpm -r --filter @himorishige/hatago-* run test:forks",
     "serve:http": "pnpm -C packages/mcp-hub serve:http",
     "serve:stdio": "pnpm -C packages/mcp-hub serve:stdio",
-    "bench:empty": "node bench/stdio-compare.mjs --config bench/configs/hatago-empty.config.json --npm 0.0.10 --iters 200",
-    "bench:fixture": "node bench/stdio-compare.mjs --config bench/configs/hatago-fixture.config.json --npm 0.0.10 --iters 200"
+    "bench:empty": "node bench/stdio-compare.mjs --config bench/configs/hatago-empty.config.json --npm 0.0.11 --iters 200",
+    "bench:fixture": "node bench/stdio-compare.mjs --config bench/configs/hatago-fixture.config.json --npm 0.0.11 --iters 200"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "CLI for Hatago MCP Hub",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-core",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Core types and protocol definitions for Hatago MCP Hub",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -13,7 +13,7 @@ export const HATAGO_SERVER_NAME = 'hatago-mcp-hub' as const;
  * Hatago version string.
  * NOTE: This should be updated by release tooling.
  */
-export const HATAGO_VERSION = '0.0.10' as const;
+export const HATAGO_VERSION = '0.0.11' as const;
 
 /** serverInfo payload used in initialize responses */
 export const HATAGO_SERVER_INFO = {

--- a/packages/hub-management/package.json
+++ b/packages/hub-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-hub-management",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Management extensions for Hatago Hub (activation/idle/metadata/audit)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-hub",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "User-friendly facade for Hatago MCP Hub",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-hub/package.json
+++ b/packages/mcp-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-mcp-hub",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Unified MCP Hub for managing multiple Model Context Protocol servers",
   "type": "module",
   "main": "./dist/node/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-runtime",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Runtime components for Hatago MCP Hub - session, registry, router, and retry management",
   "type": "module",
   "sideEffects": false,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-server",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "NPX-ready MCP Hub server for Claude Code and other AI assistants",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/test-fixtures/package.json
+++ b/packages/test-fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-test-fixtures",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-test-utils",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@himorishige/hatago-transport",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Transport abstractions and implementations for Hatago MCP Hub",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.0.11 to ensure PR #51 changes are included in the npm package.

### Background
- PR #51 fixed transport selection for HTTP vs SSE server types
- This fix needs to be included in the published npm package

### Changes
- Updated version from 0.0.10 to 0.0.11 in all package.json files (11 packages + 3 examples)
- Updated hardcoded version in `/packages/core/src/constants.ts`
- Updated version references in examples and benchmark files

### Files Changed (18 total)
- 14 package.json files
- 2 source code files with hardcoded versions
- 2 benchmark configuration files

## Checklist
- [x] All version references updated to 0.0.11
- [x] No remaining 0.0.10 references in codebase
- [x] Follows conventional commit format

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>